### PR TITLE
Prevent rollbacks on failing registration

### DIFF
--- a/sbin/rollback-reset-registration
+++ b/sbin/rollback-reset-registration
@@ -21,6 +21,13 @@ if [ "${CURRENT_SNAPSHOT_ID}" -ne "${DEFAULT_SNAPSHOT_ID}" ]; then
   exit
 fi
 
-if SUSEConnect --rollback; then
-  rm -f ${VARDIR}/check-registration
-fi
+# systemd does currently not support "Restart=" for oneshot services
+# (https://github.com/systemd/systemd/issues/2582), so implement a manual
+# retry algorithm
+for i in {1..5}; do
+  [ $i == 1 ] || sleep 2
+  if SUSEConnect --rollback; then
+    rm -f ${VARDIR}/check-registration
+    exit 0
+  fi
+done

--- a/systemd/rollback.service
+++ b/systemd/rollback.service
@@ -3,6 +3,7 @@ Description=Rollback Helper for Registration
 DefaultDependencies=no
 Requires=network-online.target
 After=local-fs.target network-online.target
+Before=transactional-update.timer salt-minion.service cloud-config.service
 ConditionPathExists=/var/lib/rollback/check-registration
 
 [Service]


### PR DESCRIPTION
There are currently two open bugs for CaaSP which cause a rollback of a system to the previous release after successful migration (https://bugzilla.suse.com/show_bug.cgi?id=1108618 & https://bugzilla.suse.com/show_bug.cgi?id=1113048). This will happen if the SUSEConnect call was not successful, i.e. the release information is still the old one.

These two commits try to make the behaviour more reliable to prevent these situations.