### PR TITLE
Return error in case of SUSEConnect --rollback fails

### DIFF
--- a/sbin/rollback-reset-registration
+++ b/sbin/rollback-reset-registration
@@ -31,3 +31,5 @@ for i in {1..5}; do
     exit 0
   fi
 done
+
+exit 1


### PR DESCRIPTION
It would be nice to let the users know that `SUSEConnect --rollback`
failed all attemtps as the error code is visible in `rollback.service`.

```
● rollback.service - Rollback Helper for Registration
     Loaded: loaded (/usr/lib/systemd/system/rollback.service; enabled;
vendor preset: enabled)
     Active: failed (Result: exit-code) since Thu 2022-05-26 08:56:41
UTC; 3s ago
    Process: 3254 ExecStart=/usr/sbin/rollback-reset-registration
(code=exited, status=1/FAILURE)
   Main PID: 3254 (code=exited, status=1/FAILURE)

May 26 08:56:34 localhost rollback-reset-registration[3294]: Error:
Registration server returned 'No activated system subscription with
product 'SUSE Linux Enterprise Server 15 SP3 x86_64' found' (422)
May 26 08:56:36 localhost rollback-reset-registration[3325]: Starting to
sync system product activations to the server. This can take some
time...
May 26 08:56:36 localhost rollback-reset-registration[3325]: Error:
Registration server returned 'No activated system subscription with
product 'SUSE Linux Enterprise Server 15 SP3 x86_64' found' (422)
May 26 08:56:39 localhost rollback-reset-registration[3356]: Starting to
sync system product activations to the server. This can take some
time...
May 26 08:56:39 localhost rollback-reset-registration[3356]: Error:
Registration server returned 'No activated system subscription with
product 'SUSE Linux Enterprise Server 15 SP3 x86_64' found' (422)
May 26 08:56:41 localhost rollback-reset-registration[3387]: Starting to
sync system product activations to the server. This can take some
time...
May 26 08:56:41 localhost rollback-reset-registration[3387]: Error:
Registration server returned 'No activated system subscription with
product 'SUSE Linux Enterprise Server 15 SP3 x86_64' found' (422)
May 26 08:56:41 localhost systemd[1]: rollback.service: Main process
exited, code=exited, status=1/FAILURE
May 26 08:56:41 localhost systemd[1]: rollback.service: Failed with
result 'exit-code'.
May 26 08:56:41 localhost systemd[1]: Failed to start Rollback Helper
for Registration.
```